### PR TITLE
Connection check is done in netconn API. Don't check for conn->pcb.tcp->state.

### DIFF
--- a/websocket.c
+++ b/websocket.c
@@ -44,7 +44,7 @@ void ws_disconnect_client(ws_client_t* client,bool mask) {
 }
 
 bool ws_is_connected(ws_client_t client) {
-  if((client.conn) && (client.conn->pcb.tcp->state == ESTABLISHED))
+  if(client.conn)
     return 1;
   return 0;
 }


### PR DESCRIPTION
Connection is checked when netconn API is called, so it is possible to identify connection errors in ws_server_send*(). Additionally, conn->pcb.tcp->state is not available when client is disconnected (or unplugged), including situations when the device has been disconnected from wi-fi STA.

This PR seems to solve problem related in #6.