### PR TITLE
Bug Fix: WEBSOCKET_CONNECT event emmited before the client is connected

### DIFF
--- a/websocket_server.c
+++ b/websocket_server.c
@@ -202,8 +202,8 @@ int ws_server_add_client_protocol(struct netconn* conn,
 
   for(int i=0;i<WEBSOCKET_SERVER_MAX_CLIENTS;i++) {
     if(clients[i].conn) continue;
-    callback(i,WEBSOCKET_CONNECT,NULL,0);
     clients[i] = ws_connect_client(conn,url,NULL,callback);
+    callback(i,WEBSOCKET_CONNECT,NULL,0);
     if(!ws_is_connected(clients[i])) {
       callback(i,WEBSOCKET_DISCONNECT_ERROR,NULL,0);
       ws_disconnect_client(&clients[i], 0);


### PR DESCRIPTION
During `WEBSOCKET_CONNECT`the websocket callback is called before `ws_connect_client`.

https://github.com/Molorius/esp32-websocket/blob/12c4ad311f3eb5a88bd0ad9d51bc9d91613b1bee/websocket_server.c#L203-L206

This means that you can't send a greeting message to the socket upon connection as the socket isn't associated yet and any attempt to send a message would return a `0`.

This fixes that by calling the callback after calling `ws_connect_client`.

Signed-off-by: Itay Grudev <itay+89bf5c[]grudev.com>