### PR TITLE
use strcasestr instead of strstr

### DIFF
--- a/websocket_server.c
+++ b/websocket_server.c
@@ -154,12 +154,12 @@ static bool prepare_response(char* buf,uint32_t buflen,char* handshake,char* pro
   char* key_end;
   char* hashed_key;
 
-  if(!strstr(buf,WS_HEADER)) return 0;
+  if(!strcasestr(buf,WS_HEADER)) return 0;
   if(!buflen) return 0;
-  key_start = strstr(buf,WS_KEY);
+  key_start = strcasestr(buf,WS_KEY);
   if(!key_start) return 0;
   key_start += 19;
-  key_end = strstr(key_start,"\r\n");
+  key_end = strcasestr(key_start,"\r\n");
   if(!key_end) return 0;
 
   hashed_key = ws_hash_handshake(key_start,key_end-key_start);


### PR DESCRIPTION
hi, thanks for this useful library.
as mentioned in this [ link](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#:~:text=HTTP%20headers%20let%20the%20client%20and%20the%20server%20pass%20additional%20information%20with%20an%20HTTP%20request%20or%20response.%20An%20HTTP%20header%20consists%20of%20its%20case%2Dinsensitive%20name%20followed%20by%20a%20colon%20(%3A)%2C%20then%20by%20its%20value.) Http headers are case-insensitive, `strstr` is case sensitive, some client library change header `key`s to lowercase (in our case `dart:io` ), and this will create problems when clients try to connect to websocket, because `prepare_response` function doesn't accept their headers. 
`strcasestr` is not case-sensitive so i think it is better to use it instead of `strstr` in this case.