### PR TITLE
NULL-ing task pointer after `ws_server_stop` call

### DIFF
--- a/websocket_server.c
+++ b/websocket_server.c
@@ -138,6 +138,7 @@ int ws_server_start() {
 int ws_server_stop() {
   if(!xtask) return 0;
   vTaskDelete(xtask);
+  xtask = NULL;
   return 1;
 }
 


### PR DESCRIPTION
`vTaskDelete` does not set pointer to NULL by itself. Once server is stopped, it cannot be started again, as there's `if(xtask) return 0;` check in `ws_server_start`.